### PR TITLE
Fix hashcat not found error

### DIFF
--- a/help_crack_banthex.py
+++ b/help_crack_banthex.py
@@ -320,9 +320,9 @@ class HelpCrack(object):
         # hashcat
         bits = platform.architecture()[0]
         if bits == '64bit':
-            tools += run_hashcat(['hashcat64.bin', 'hashcat64', 'hashcat'])
+            tools += run_hashcat(['hashcat64.bin', 'hashcat64', 'hashcat', 'hashcat.bin'])
         else:
-            tools += run_hashcat(['hashcat32.bin', 'hashcat32', 'hashcat'])
+            tools += run_hashcat(['hashcat32.bin', 'hashcat32', 'hashcat', 'hashcat.bin'])
 
         # John the Ripper
         tools += run_jtr()


### PR DESCRIPTION
Close #2

Fix for hashcat not found error message when we use french install of hashcat on Linux.